### PR TITLE
Add simple typeahead search example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Typeahead Search</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      padding: 20px;
+    }
+    #suggestions {
+      border: 1px solid #ccc;
+      max-height: 150px;
+      overflow-y: auto;
+    }
+    #suggestions div {
+      padding: 4px 8px;
+      cursor: pointer;
+    }
+    #suggestions div:hover {
+      background-color: #f0f0f0;
+    }
+  </style>
+</head>
+<body>
+  <h1>Typeahead Search Box</h1>
+  <input type="text" id="search" placeholder="Search..." autocomplete="off" />
+  <div id="suggestions"></div>
+  <script>
+    const data = [
+      'apple',
+      'banana',
+      'cherry',
+      'date',
+      'elderberry',
+      'fig',
+      'grape',
+      'honeydew'
+    ];
+
+    const input = document.getElementById('search');
+    const suggestions = document.getElementById('suggestions');
+
+    input.addEventListener('input', () => {
+      const query = input.value.toLowerCase();
+      suggestions.innerHTML = '';
+      if (!query) {
+        return;
+      }
+      const matches = data.filter(item => item.toLowerCase().startsWith(query));
+      matches.forEach(item => {
+        const div = document.createElement('div');
+        div.textContent = item;
+        div.addEventListener('click', () => {
+          input.value = item;
+          suggestions.innerHTML = '';
+        });
+        suggestions.appendChild(div);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/read.me
+++ b/read.me
@@ -1,3 +1,3 @@
-fir
-ooc
-
+This repository now contains a simple example demonstrating a typeahead search
+box. Open `index.html` in your browser and start typing to see suggestions from
+an in-memory list of fruit names.


### PR DESCRIPTION
## Summary
- add a minimal `index.html` page with a typeahead search box
- update `read.me` with instructions for the new demo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f5ff4b5208326894e3a0640835a77